### PR TITLE
Add support for range header to get-file endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "extend": "^3.0.2",
         "json5": "^2.1.3",
         "mime-types": "^2.1.34",
+        "range-parser": "^1.2.1",
         "retry-fn": "^1.0.1",
         "terminal-kit": "^2.4.0",
         "tty-table": "^4.1.5",
@@ -6594,6 +6595,14 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "extend": "^3.0.2",
     "json5": "^2.1.3",
     "mime-types": "^2.1.34",
+    "range-parser": "^1.2.1",
     "retry-fn": "^1.0.1",
     "terminal-kit": "^2.4.0",
     "tty-table": "^4.1.5",

--- a/src/http/index.js
+++ b/src/http/index.js
@@ -53,7 +53,6 @@ module.exports = (argv, config) => {
       storage = client.getStorage(storageId);
     } catch (ex) {
       client.emit('warn', { message: 'Storage exception', stack: ex.stack || ex });
-
       res.statusMessage = 'Invalid storage';
       res.statusCode = 404;
       return void res.end();

--- a/src/http/set-headers.js
+++ b/src/http/set-headers.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { formatDate } = require('../util/http-date');
 
-module.exports = ({ storage, fileKey, urlInfo, res, headers, realContentType, config: { cors } }) => {
+module.exports = ({ storage, req, fileKey, urlInfo, res, headers, realContentType, config: { cors } }) => {
   // always available
   if (realContentType) res.setHeader('Content-Type', realContentType);
 
@@ -31,5 +31,9 @@ module.exports = ({ storage, fileKey, urlInfo, res, headers, realContentType, co
   if (typeof cors === 'object') {
     // apply cors headers
     Object.keys(cors).forEach(key => res.setHeader(key, cors[key]));
+  }
+
+  if (req.method === 'GET' || req.method === 'HEAD') {
+    res.setHeader('Accept-Ranges', 'bytes');
   }
 };

--- a/test/integration/cmds/server.tests.js
+++ b/test/integration/cmds/server.tests.js
@@ -81,6 +81,18 @@ describe('# src/cmds/server.js', async () => {
     expect(data.files[1].Key).to.equal(`tmp${path.sep}test2.txt`);
   });
 
+  it('GET myVideo.mp4 with range from local storage', async () => {
+    writeFileSync('test/fs/local1/tmp/myVideo.mp4', Buffer.alloc(10000));
+    const { data, status, headers } = await axios.get('http://localhost:4080/local/tmp/myVideo.mp4', {
+      headers: { Range: 'bytes=0-100' }
+    });
+    expect(status).to.equal(206);
+    expect(headers['content-type']).to.equal('video/mp4');
+    expect(headers['content-range']).to.equal('bytes 0-100/10000');
+    expect(headers['accept-ranges']).to.equal('bytes');
+    expect(data.length).to.equal(101);
+  });
+
   it('PUT test1.txt to local storage', async () => {
     expect(existsSync('test/fs/local1/tmp/test1.txt')).to.be.false;
     const { data, status, headers } = await axios.put('http://localhost:4080/local/tmp/test1.txt', 'test1', {


### PR DESCRIPTION
Safari browsers require byte range support for properly playing mp4 videos, so this PR adds support for the range header to handle this use case.